### PR TITLE
Fix unexpected linter action input targets

### DIFF
--- a/.github/workflows/ansible-linting-check.yml
+++ b/.github/workflows/ansible-linting-check.yml
@@ -13,5 +13,3 @@ jobs:
 
     - name: "Lint Ansible Playbook"
       uses: "ansible/ansible-lint-action@v6.3.0"
-      with:
-        targets: "."


### PR DESCRIPTION
```
Warning: Unexpected input(s) 'targets', valid inputs are ['entryPoint', 'args', 'path']
```

The ansible-lint GitHub Action does not have a targets input any longer
which results in a warning. With this change we get rid of the
warning.