### PR TITLE
Replace deprecated include with import_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,2 @@
- - ansible.builtin.include: "unattended-upgrades.yml"
+ - ansible.builtin.import_tasks: "unattended-upgrades.yml"
    tags: "unattended"

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -30,7 +30,7 @@
     update_cache: "yes"
 
 - name: "install reboot dependencies"
-  ansible.builtin.include: "reboot.yml"
+  ansible.builtin.import_tasks: "reboot.yml"
   when: "unattended_automatic_reboot | bool"
 
 - name: "create APT auto-upgrades configuration"


### PR DESCRIPTION
To get rid of the following warning:
```
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```