### PR TITLE
Fix 'All names should start with an uppercase letter' warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,3 @@
- - ansible.builtin.import_tasks: "unattended-upgrades.yml"
-   tags: "unattended"
+---
+- ansible.builtin.import_tasks: "unattended-upgrades.yml"
+  tags: "unattended"

--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -1,7 +1,7 @@
 ---
 # Ignored, since newer distros don't need this package
 # https://github.com/jnv/ansible-role-unattended-upgrades/issues/6
-- name: "install update-notifier-common"
+- name: "Install update-notifier-common"
   ansible.builtin.apt:
     pkg: "update-notifier-common"
     state: "present"

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -1,20 +1,20 @@
 ---
-- name: "add distribution-specific variables"
+- name: "Add distribution-specific variables"
   ansible.builtin.include_vars: "{{ ansible_distribution }}.yml"
 
-- name: "add Debian Wheezy workaround"
+- name: "Add Debian Wheezy workaround"
   ansible.builtin.include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml"
   when:
     - "ansible_distribution == 'Debian'"
     - "ansible_distribution_release == 'wheezy'"
 
-- name: "add Debian Bullseye workaround"
+- name: "Add Debian Bullseye workaround"
   ansible.builtin.include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml"
   when:
     - "ansible_distribution == 'Debian'"
     - "ansible_distribution_release == 'bullseye'"
 
-- name: "install powermgmt-base"
+- name: "Install powermgmt-base"
   ansible.builtin.apt:
     pkg:
     state: "present"
@@ -22,18 +22,18 @@
     update_cache: "yes"
   when: "unattended_only_on_ac_power"
 
-- name: "install unattended-upgrades"
+- name: "Install unattended-upgrades"
   ansible.builtin.apt:
     pkg: "unattended-upgrades"
     state: "present"
     cache_valid_time: "{{ unattended_cache_valid_time }}"
     update_cache: "yes"
 
-- name: "install reboot dependencies"
+- name: "Install reboot dependencies"
   ansible.builtin.import_tasks: "reboot.yml"
   when: "unattended_automatic_reboot | bool"
 
-- name: "create APT auto-upgrades configuration"
+- name: "Create APT auto-upgrades configuration"
   ansible.builtin.template:
     src: "auto-upgrades.j2"
     dest: "/etc/apt/apt.conf.d/20auto-upgrades"
@@ -41,7 +41,7 @@
     group: "root"
     mode: "0644"
 
-- name: "create unattended-upgrades configuration"
+- name: "Create unattended-upgrades configuration"
   ansible.builtin.template:
     src: "unattended-upgrades.j2"
     dest: "/etc/apt/apt.conf.d/50unattended-upgrades"


### PR DESCRIPTION
This PR fixes several `ansible-lint` warnings -  see #15.