### PR TITLE
Fix deprecation warning in GitHub Actions

### DIFF
--- a/.github/workflows/prepare-action/action.yml
+++ b/.github/workflows/prepare-action/action.yml
@@ -9,7 +9,7 @@ runs:
       shell: "bash"
 
     - name: "Set up Python 3."
-      uses: "actions/setup-python@v3"
+      uses: "actions/setup-python@v4"
       id: "setup-python"
       with:
         python-version: "3.10"


### PR DESCRIPTION
So far GitHub Actions show a lot of deprecation warnings. This change removes them.