### PR TITLE
Fix minimum specification of Ansible version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: "hifis"
   description: "Setup unattended-upgrades on Debian-based systems"
   license: "GPLv2"
-  min_ansible_version: "1.4"
+  min_ansible_version: "2.12"
   platforms:
   - name: "Ubuntu"
     versions:


### PR DESCRIPTION
We will officially support Ansible versions that are currently under active maintenance -
https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs. Older versions might work but are not officially support by this role.

Closes #75 