### PR TITLE
Unattended-Upgrade::Sender support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ On some hosts you may find that the unattended-upgrade's cron file `/etc/cron.da
 * `unattended_mail`:
   * Default: `false` (don't send any e-mail)
   * Description: E-mail address to send information about upgrades or problems with unattended upgrades.
+* `unattended_mail_sender`:
+  * Default: `false` (same as `root`)
+  * Description: Use the specified value in the "From" field of outgoing mails
 * `unattended_mail_only_on_error`:
   * Default: `false`
   * Description: Send e-mail only on errors, otherwise e-mail will be sent every time there's a package upgrade.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,6 +42,10 @@ unattended_install_on_shutdown: false
 # 'mailx' must be installed.
 unattended_mail: false
 
+# Unattended-Upgrade::Sender
+# Use the specified value in the "From" field of outgoing mails.
+unattended_mail_sender: false
+
 #Unattended-Upgrade::MailOnlyOnError
 # Set this value to "true" to get emails only on errors. Default
 # is to always send a mail if Unattended-Upgrade::Mail is set

--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -81,6 +81,10 @@ Unattended-Upgrade::InstallOnShutdown "true";
 Unattended-Upgrade::Mail "{{unattended_mail}}";
 {% endif %}
 
+{% if unattended_mail_sender %}
+Unattended-Upgrade::Sender "{{unattended_mail_sender}}";
+{% endif %}
+
 {% if unattended_mail_only_on_error %}
 // Set this value to "true" to get emails only on errors. Default
 // is to always send a mail if Unattended-Upgrade::Mail is set


### PR DESCRIPTION
There is a little-known configuration parameter called `Unattended-Upgrade::Sender` that allows changing the sender of outgoing mails. By default, it sends as `root`. This PR allows changing this parameter.

[See unattended-upgrades README](https://github.com/mvo5/unattended-upgrades/blob/master/README.md#supported-options-reference)