### PR TITLE
Test custom apt-daily timers

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -25,6 +25,11 @@ provisioner:
           unattended_remove_unused_kernel_packages: true
           unattended_only_on_ac_power: true
           unattended_mail_sender: "jane@example.org"
+          unattended_systemd_timer_override: true
+          unattended_apt_daily_oncalendar: "*-*-* 11:08"
+          unattended_apt_daily_randomizeddelaysec: "0s"
+          unattended_apt_daily_upgrade_oncalendar: "*-*-* 11:31"
+          unattended_apt_daily_upgrade_randomizeddelaysec: "0s"
   playbooks:
     prepare: "prepare.yml"
     check: "converge.yml"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -68,4 +68,12 @@
       failed_when: "dry_run.rc != 0"
       changed_when: false
 
+    - name: "Verify custom apt-daily timers"  # noqa command-instead-of-shell
+      ansible.builtin.shell:
+        cmd: "{{ item }}"
+      changed_when: false
+      loop:
+        - 'systemctl list-timers apt-daily* | grep apt-daily.service | grep "11:08:00"'
+        - 'systemctl list-timers apt-daily* | grep apt-daily-upgrade.service | grep "11:31:00"'
+
 ...


### PR DESCRIPTION
This PR adds a test for custom apt-daily timers to the Molecule *verify* step. This is a follow-up for #120 