### PR TITLE
fix: allow ${distro_codename}-security on Debian bookworm

### DIFF
--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -1,12 +1,13 @@
 ---
 - name: "Add distribution-specific variables"
-  ansible.builtin.include_vars: "{{ ansible_distribution }}.yml"
-
-- name: "Add Debian Bullseye workaround"
-  ansible.builtin.include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml"
-  when:
-    - "ansible_distribution == 'Debian'"
-    - "ansible_distribution_release == 'bullseye'"
+  ansible.builtin.include_vars: "{{ lookup('ansible.builtin.first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution }}.yml"
+      paths:
+        - 'vars'
 
 - name: "Install powermgmt-base"
   ansible.builtin.apt:

--- a/vars/Debian-bullseye.yml
+++ b/vars/Debian-bullseye.yml
@@ -1,9 +1,0 @@
----
-# From https://metadata.ftp-master.debian.org/changelogs//main/u/unattended-upgrades/unattended-upgrades_2.8_changelog
-#  Allow both ${distro_codename} or ${distro_codename}-security on Debian
-#  as security update codenames. The latter will be used starting with
-#  Bullseye, but to help backporting and testing the configuration file keeps
-#  working on Buster and older releases. (Closes: #933138)
-__unattended_origins_patterns:
-  - 'origin=Debian,codename=${distro_codename},label=Debian-Security'
-  - 'origin=Debian,codename=${distro_codename}-security,label=Debian-Security'

--- a/vars/Debian-buster.yml
+++ b/vars/Debian-buster.yml
@@ -1,0 +1,3 @@
+---
+__unattended_origins_patterns:
+  - 'origin=Debian,codename=${distro_codename},label=Debian-Security'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,9 @@
 ---
+# From https://metadata.ftp-master.debian.org/changelogs//main/u/unattended-upgrades/unattended-upgrades_2.8_changelog
+#  Allow both ${distro_codename} or ${distro_codename}-security on Debian
+#  as security update codenames. The latter will be used starting with
+#  Bullseye, but to help backporting and testing the configuration file keeps
+#  working on Buster and older releases. (Closes: #933138)
 __unattended_origins_patterns:
   - 'origin=Debian,codename=${distro_codename},label=Debian-Security'
+  - 'origin=Debian,codename=${distro_codename}-security,label=Debian-Security'


### PR DESCRIPTION
* Closes #146 