### PR TITLE
fix: reformat allowed origins pattern

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,6 +13,8 @@ platforms:
     tty: true
 provisioner:
   name: "ansible"
+  options:
+    diff: True
   inventory:
     hosts:
       all:

--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -40,15 +40,14 @@ APT::Periodic::RandomSleep "{{unattended_random_sleep}}";
 // upgraded.
 Unattended-Upgrade::Origins-Pattern {
 {% if unattended_origins_patterns is defined %}
-  {%- for origin in unattended_origins_patterns %}
+{% for origin in unattended_origins_patterns %}
     "{{ origin }}";
-  {%- endfor %}
+{% endfor %}
 {% else %}
-  {%- for origin in __unattended_origins_patterns %}
+{% for origin in __unattended_origins_patterns %}
     "{{ origin }}";
-  {%- endfor %}
+{% endfor %}
 {% endif %}
-
 };
 
 // List of packages to not update (regexp are supported)


### PR DESCRIPTION
Before (Debian 11 Bullseye):
```
Unattended-Upgrade::Origins-Pattern {
    "origin=Debian,codename=${distro_codename},label=Debian-Security";    "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
};
```

After:
```
Unattended-Upgrade::Origins-Pattern {
    "origin=Debian,codename=${distro_codename},label=Debian-Security";
    "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
};
```