### PR TITLE
Disable apt cache updates when removing repositories from sources.list

### DIFF
--- a/roles/gitlab/tasks/install.yml
+++ b/roles/gitlab/tasks/install.yml
@@ -26,12 +26,14 @@
         repo: "deb {{ gitlab_repo_url }} {{ ansible_facts.distribution_release }} main"
         state: "absent"
         filename: "gitlab_{{ gitlab_edition }}"
+        update_cache: false
 
     - name: "Remove GitLab source APT repository from sources.list"
       ansible.builtin.apt_repository:
         repo: "deb-src {{ gitlab_repo_url }} {{ ansible_facts.distribution_release }} main"
         state: "absent"
         filename: "gitlab_{{ gitlab_edition }}"
+        update_cache: false
 
     - name: "Add GitLab APT repository"
       ansible.builtin.deb822_repository:

--- a/roles/zammad/tasks/install.yml
+++ b/roles/zammad/tasks/install.yml
@@ -40,6 +40,7 @@
         repo: "deb https://dl.packager.io/srv/deb/zammad/zammad/{{ zammad_release_channel }}/ubuntu {{ ansible_distribution_version }} main"
         state: "absent"
         filename: "zammad"
+        update_cache: false
 
     - name: "Install | Add Zammad DEB repository"
       ansible.builtin.deb822_repository:


### PR DESCRIPTION
Fixes the following error during apt repository removal:

```text
TASK [hifis.toolkit.gitlab : Remove GitLab APT repository from sources.list] ***
[WARNING]: Failed to update cache after 1 due to  retry, retrying
[WARNING]: Sleeping for 2 seconds, before attempting to update the cache again
[WARNING]: Failed to update cache after 2 due to  retry, retrying
[WARNING]: Sleeping for 3 seconds, before attempting to update the cache again
[WARNING]: Failed to update cache after 3 due to  retry, retrying
[WARNING]: Sleeping for 5 seconds, before attempting to update the cache again
[WARNING]: Failed to update cache after 4 due to  retry, retrying
[WARNING]: Sleeping for 9 seconds, before attempting to update the cache again
[WARNING]: Failed to update cache after 5 due to  retry, retrying
[WARNING]: Sleeping for 13 seconds, before attempting to update the cache again
fatal: [gitlab-staging1]: FAILED! => 
    changed: false
    msg: 'Failed to update apt cache after 5 retries: '
```