### PR TITLE
Make sure to run registry metadata database migrations

### DIFF
--- a/roles/gitlab/handlers/main.yml
+++ b/roles/gitlab/handlers/main.yml
@@ -20,6 +20,10 @@
   listen: "GitLab has been installed or upgraded"
   when: "gitlab_is_primary"
 
+- name: "Trigger registry metadata database migrations"
+  ansible.builtin.include_tasks: "registry_metadata_db.yml"
+  when: "gitlab_is_primary"
+
 - name: "Reconfigure Non Primary GitLab"
   become: true
   ansible.builtin.shell:

--- a/roles/gitlab/handlers/registry_metadata_db.yml
+++ b/roles/gitlab/handlers/registry_metadata_db.yml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+
+- name: "Check if registry configuration exists"
+  ansible.builtin.set_fact:
+    __gitlab_registry_config: "{{ item.registry }}"
+  when: "item.registry is defined"
+  loop: "{{ gitlab_additional_configurations }}"
+
+- name: "Check if database key is defined in registry"
+  ansible.builtin.set_fact:
+    __gitlab_registry_database_used: "{{ __gitlab_registry_config | default([]) | selectattr('key', '==', 'database') | list | length > 0 }}"
+
+- name: "Run registry metadata database migrations"
+  become: true
+  ansible.builtin.command: "gitlab-ctl registry-database migrate up --skip-post-deployment"
+  changed_when: true
+  when:
+    - "__gitlab_registry_database_used"

--- a/roles/gitlab/tasks/configure.yml
+++ b/roles/gitlab/tasks/configure.yml
@@ -17,6 +17,7 @@
   no_log: "{{ gitlab_hide_sensitive_changes }}"
   notify:
     - "Reconfigure Primary GitLab"
+    - "Trigger registry metadata database migrations"
     - "Reconfigure Non Primary GitLab"
 
 - name: "Ensure gitaly['configuration'] is not present in gitlab_additional_configurations"
@@ -55,6 +56,7 @@
   no_log: "{{ gitlab_hide_sensitive_changes }}"
   notify:
     - "Reconfigure Primary GitLab"
+    - "Trigger registry metadata database migrations"
     - "Reconfigure Non Primary GitLab"
 
 - name: "Create file to prevent Gitlab to restart before migrations"

--- a/roles/gitlab/tasks/reconfigure.yml
+++ b/roles/gitlab/tasks/reconfigure.yml
@@ -21,6 +21,26 @@
   when:
     - "not gitlab_is_primary"
 
+- name: "Trigger registry metadata database migrations"
+  when: "gitlab_is_primary"
+  block:
+    - name: "Check if registry configuration exists"
+      ansible.builtin.set_fact:
+        __gitlab_registry_config: "{{ item.registry }}"
+      when: "item.registry is defined"
+      loop: "{{ gitlab_additional_configurations }}"
+
+    - name: "Check if database key is defined in registry"
+      ansible.builtin.set_fact:
+        __gitlab_registry_database_used: "{{ __gitlab_registry_config | default([]) | selectattr('key', '==', 'database') | list | length > 0 }}"
+
+    - name: "Run registry metadata database migrations"
+      become: true
+      ansible.builtin.command: "gitlab-ctl registry-database migrate up --skip-post-deployment"
+      changed_when: true
+      when:
+        - "__gitlab_registry_database_used"
+
 - name: "Remove file that indicates a failed reconfigure"
   ansible.builtin.file:
     path: "/etc/gitlab/reconfigure_failed"


### PR DESCRIPTION
So far registry database migrations were not automatically triggered. This change checks, if the registry metadata database is configured. If the database is configured it makes sure to trigger database migrations.

https://docs.gitlab.com/administration/packages/container_registry_metadata_database/#database-migrations