### PR TITLE
gitlab_runner: add option to hide sensitive changes in diffs

### DIFF
--- a/roles/gitlab_runner/README.md
+++ b/roles/gitlab_runner/README.md
@@ -84,6 +84,11 @@ Decide wether to install Docker via
 Docker is required for the `docker` executor but not for the
 `docker+machine` executor.
 
+```yaml
+gitlab_runner_hide_sensitive_changes: true
+```
+Do not display sensitive changes in diffs by default.
+
 ### Docker-machine variables
 
 ```yaml

--- a/roles/gitlab_runner/defaults/main.yml
+++ b/roles/gitlab_runner/defaults/main.yml
@@ -52,3 +52,6 @@ gitlab_runner_autoscaler_plugin_url: "https://github.com/sardinasystems/fleeting
 gitlab_runner_autoscaler_plugin_checksumfile: "https://github.com/sardinasystems/fleeting-plugin-openstack/releases/download/{{ gitlab_runner_autoscaler_plugin_version }}/fleeting-plugin-openstack_{{ gitlab_runner_autoscaler_binary_version }}_sha512-checksums.txt"
 
 gitlab_runner_butane_config_template: "butane-config.bu.j2"
+
+# Do not display sensitive changes in diffs by default
+gitlab_runner_hide_sensitive_changes: true

--- a/roles/gitlab_runner/tasks/install.autoscaler-plugin.yml
+++ b/roles/gitlab_runner/tasks/install.autoscaler-plugin.yml
@@ -67,6 +67,6 @@
     owner: "root"
     group: "root"
     mode: '0600'
-  no_log: true
+  no_log: "{{ gitlab_runner_hide_sensitive_changes }}"
 
 ...

--- a/roles/gitlab_runner/tasks/main.yml
+++ b/roles/gitlab_runner/tasks/main.yml
@@ -42,7 +42,7 @@
 - name: "Initialize docker-machine"
   ansible.builtin.include_tasks: "docker-machine-init.yml"
   when: "__gitlab_runner_install_docker_machine"
-  no_log: true
+  no_log: "{{ gitlab_runner_hide_sensitive_changes }}"
   loop: "{{ gitlab_runner_list }}"
   loop_control:
     loop_var: "gitlab_runner"
@@ -63,7 +63,7 @@
     group: "{{ gitlab_runner_config_group | default('root') }}"
     mode: "0600"
   notify: "Restart GitLab-Runner"
-  no_log: true
+  no_log: "{{ gitlab_runner_hide_sensitive_changes }}"
   vars:
     __ignition_content: "{{ __ignition_json['content'] | b64decode }}"
   when: "not __gitlab_runner_is_initial_dryrun"


### PR DESCRIPTION
Introduce new variable `gitlab_runner_hide_sensitive_changes` (default: true). Replaces hardcoded `no_log: true` with conditional `no_log` usage to allow hiding sensitive values in diffs by default, while keeping possibility to override for debugging.